### PR TITLE
Judge invites emails with Mailgun.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Before starting the app, set the following environment variables:
 * `SQLALCHEMY_DATABASE_URI` - you only need to set this if you're doing
   something nonstandard
 
+The following environmental variables should be set prior to sending emails:
+
+* `MAILGUN_DOMAIN` - Already-added domain name in Mailgun.
+* `MAILGUN_API_KEY` - API key corresponding to the domain name.
+
 ## Use
 
 Using the admin interface on `/admin`, input data for all the projects and

--- a/mail.py
+++ b/mail.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+import os
+from email.utils import formataddr
+
+import requests
+
+MAILGUN_MESSAGES_API_URL = 'https://api.mailgun.net/v3/{domain}/messages'
+SENDER_IDENTITY = ('HackMIT Judging', 'judging-noreply@{domain}')
+JUDGE_INVITE_TITLE = 'HackMIT Juding System Access'
+JUDGE_INVITE_TEMPLATE = """Dear {judge_name},
+
+Welcome to HackMIT judging! This email contains your magic link to the judging system.
+If you are no longer judging, please do NOT access this link as it will affect judging results.
+DO NOT SHARE your magic link with others - it is associated with your email address, and it's one account per person.
+Judging will be explained during the judging orientation. Please do not open the link until then.
+
+You may sign in to judging by accessing the following link: {magic_link} .
+
+All questions should be directed to HackMIT organizers. Please do not reply to this automatic email.
+
+HackMIT Team
+
+
+(You are receiving this email because you are a judge at this event. If you do not want to receive further judging-related emails, please contact the organizers.)
+"""
+
+
+class MailgunRequestException(Exception):
+    """Unsuccessful Mailgun HTTP request."""
+    pass
+
+
+def send_judge_email(judge_name, judge_address, magic_link):
+    """Create email and send it through Mailgun.
+
+    Arguments:
+        judge_name (str): Full name of the judge.
+        judge_address (str): Email address of the judge.
+        magic_link (str): URL-escaped magic link for access.
+    Returns:
+        True if sent successfully, False if not.
+    """
+    if not os.environ.get('MAILGUN_DOMAIN') or not os.environ.get(
+            'MAILGUN_API_KEY'):  # Require Mailgun credentials.
+        raise ValueError(
+            'Email: Environmental variables MAILGUN_DOMAIN and MAILGUN_API_KEY must be provided for outbound email.')
+
+    from_name, from_email = SENDER_IDENTITY
+    from_str = formataddr((from_name, from_email.format(
+        domain=os.environ.get('MAILGUN_DOMAIN'))))  # "Name <a@b.c>" format
+    to_str = formataddr((judge_name, judge_address))
+    message_text = JUDGE_INVITE_TEMPLATE.format(judge_name=judge_name,
+                                                magic_link=magic_link)
+
+    params = {'from': from_str,
+              'to': to_str,
+              'subject': JUDGE_INVITE_TITLE,
+              'text': message_text}
+    try:
+        mailgun_send_request(
+            os.environ.get('MAILGUN_DOMAIN'),
+            os.environ.get('MAILGUN_API_KEY'), params)
+        return True
+    except MailgunRequestException as e:
+        print(e)
+        return False
+
+
+def mailgun_send_request(domain, api_key, params):
+    """Make a POST request to Mailgun's API.
+
+    Arguments:
+        domain (str): Domain name used for Mailgun.
+        api_key (str): API key corresponding to the domain.
+        params (str): Parameters passed on to the POST request.
+    Returns:
+        True if no exceptions occured, raises MailgunRequestException() in case
+            of a non-successful status code.
+    """
+    url = MAILGUN_MESSAGES_API_URL.format(domain=domain)
+    r = requests.post(url, auth=('api', api_key), data=params)
+    if r.status_code != 200 or '"id"' not in r.text:
+        raise MailgunRequestException('{status} {text}'.format(
+            status=r.status_code, text=r.text))
+    return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scipy==0.16.0
 SQLAlchemy==1.0.8
 Werkzeug==0.10.4
 wheel==0.24.0
+requests==2.8.1

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -48,6 +48,7 @@
         <td>Previous (Id)</td>
         <td>Alpha</td>
         <td>Beta</td>
+        <td>Send Link</td>
         <td>Delete</td>
     </tr>
     {% for annotator in annotators %}
@@ -61,6 +62,12 @@
         <td>{{ annotator.prev_id | safe }}</td>
         <td>{{ annotator.alpha | safe }}</td>
         <td>{{ annotator.beta | safe }}</td>
+        <td>
+            <form action="/admin/annotator" method="post">
+                <input type="submit" name="action" value="Email" />
+                <input type="hidden" name="annotator_id" value="{{ annotator.id }}" />
+            </form>
+        </td>
         <td>
             <form action="/admin/annotator" method="post">
                 <input type="submit" name="action" value="Delete" />


### PR DESCRIPTION
#1 

This PR provides a new, not entirely user-friendly button in the Admin panel's Annotators entries that will send judging invites along with the "magic link". Email sending is done through Mailgun - its free quota is very sufficient as long as we continue to only use it for judges.

Considering that judges might not be added all at once, there isn't currently an option to send emails for all judges. However, this should not be hard to implement.

Two new environmental variables, MAILGUN_API_KEY and MAILGUN_DOMAIN, are required to be set (documented in README) if the admin wants to send emails.