### PR TITLE
add variable for email_user

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -34,6 +34,14 @@ secret_key: null
 # Optional Settings #
 #####################
 
+
+# can also be specified as the 'EMAIL_USER' environment variable
+#
+# if you are setting DISABLE_EMAIL, you can set this setting to '_unused_' (or
+# anything else).
+# defaults to value in constant EMAIL_FROM (email_from)
+email_user: null
+
 # can also be specified as the 'DATABASE_URL' or 'DB_URI' environment variable
 # defaults to 'postgresql://localhost/gavel'
 db_uri: null

--- a/gavel/settings.py
+++ b/gavel/settings.py
@@ -71,6 +71,7 @@ DISABLE_EMAIL = _bool(c.get('disable_email',  'DISABLE_EMAIL',            defaul
 EMAIL_HOST =          c.get('email_host',     'EMAIL_HOST',               default='smtp.gmail.com')
 EMAIL_PORT =      int(c.get('email_port',     'EMAIL_PORT',               default=587))
 EMAIL_FROM =          c.get('email_from',     'EMAIL_FROM')
+EMAIL_USER =          c.get('email_user',     'EMAIL_USER',               default=EMAIL_FROM)
 EMAIL_CC =      _list(c.get('email_cc',       'EMAIL_CC',                 default=[]))
 EMAIL_PASSWORD =      c.get('email_password', 'EMAIL_PASSWORD')
 EMAIL_SUBJECT =       c.get('email_subject',                              default=constants.DEFAULT_EMAIL_SUBJECT)

--- a/gavel/utils.py
+++ b/gavel/utils.py
@@ -60,7 +60,7 @@ def send_emails(emails):
     server.ehlo()
     server.starttls()
     server.ehlo()
-    server.login(settings.EMAIL_FROM, settings.EMAIL_PASSWORD)
+    server.login(settings.EMAIL_USER, settings.EMAIL_PASSWORD)
 
     exceptions = []
     for e in emails:


### PR DESCRIPTION
Some STMP systems need a different email user than the email you want to send it from (aka Sendgrid or any transactional email). In that way, I added a new optional variable to separate email login user from the email you want to send it from.