### PR TITLE
add multiple categories for projects and judges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.yaml
 *.pyc
 env/
 .vagrant/
+*.db

--- a/gavel/models/__init__.py
+++ b/gavel/models/__init__.py
@@ -9,10 +9,11 @@ class SerializableAlchemy(SQLAlchemy):
         return super(SerializableAlchemy, self).apply_driver_hacks(app, info, options)
 db = SerializableAlchemy()
 
-from gavel.models.annotator import Annotator, ignore_table
-from gavel.models.item import Item, view_table
+from gavel.models.annotator import Annotator, ignore_table, AnnotatorCategory
+from gavel.models.item import Item, view_table, ItemCategory
 from gavel.models.decision import Decision
 from gavel.models.setting import Setting
+from gavel.models.category import Category
 
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.expression import desc

--- a/gavel/models/annotator.py
+++ b/gavel/models/annotator.py
@@ -1,13 +1,61 @@
 from gavel.models import db
+from gavel.models.category import Category
 import gavel.utils as utils
 import gavel.crowd_bt as crowd_bt
 from sqlalchemy.orm.exc import NoResultFound
 from datetime import datetime
 
 ignore_table = db.Table('ignore',
-    db.Column('annotator_id', db.Integer, db.ForeignKey('annotator.id')),
+    db.Column('annotator_category_id', db.Integer, db.ForeignKey('annotator_category.id')),
     db.Column('item_id', db.Integer, db.ForeignKey('item.id'))
 )
+
+
+class AnnotatorCategory(db.Model):
+    id = db.Column('id', db.Integer, primary_key=True)
+    annotator_id = db.Column(db.Integer, db.ForeignKey('annotator.id'))
+    category_id = db.Column(db.Integer, db.ForeignKey('category.id'))
+    alpha = db.Column(db.Float)
+    beta = db.Column(db.Float)
+
+    next_id = db.Column(db.Integer, db.ForeignKey('item.id'))
+    next = db.relationship('Item', foreign_keys=[next_id], uselist=False)
+    updated = db.Column(db.DateTime)
+    prev_id = db.Column(db.Integer, db.ForeignKey('item.id'))
+    prev = db.relationship('Item', foreign_keys=[prev_id], uselist=False)
+
+    annotator = db.relationship('Annotator')
+    category = db.relationship('Category')
+
+    ignore = db.relationship('Item', secondary=ignore_table)
+
+
+    def __init__(self, annotator_id, category_id):
+        self.annotator_id = annotator_id
+        self.category_id = category_id
+        self.alpha = crowd_bt.ALPHA_PRIOR
+        self.beta = crowd_bt.BETA_PRIOR
+
+    def update_next(self, new_next):
+        if new_next is not None:
+            new_next.prioritized = False # it's now assigned, so cancel the prioritization
+            # it could happen that the judge skips the project, but that
+            # doesn't re-prioritize the project
+            self.updated = datetime.utcnow()
+            self.next = new_next.item
+        else:
+            self.next = None
+
+    @classmethod
+    def by_id(cls, uid):
+        if uid is None:
+            return None
+        try:
+            annotator = cls.query.with_for_update().get(uid)
+        except NoResultFound:
+            annotator = None
+        return annotator
+
 
 class Annotator(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
@@ -17,31 +65,22 @@ class Annotator(db.Model):
     read_welcome = db.Column(db.Boolean, default=False, nullable=False)
     description = db.Column(db.Text, nullable=False)
     secret = db.Column(db.String(32), unique=True, nullable=False)
-    next_id = db.Column(db.Integer, db.ForeignKey('item.id'))
-    next = db.relationship('Item', foreign_keys=[next_id], uselist=False)
-    updated = db.Column(db.DateTime)
-    prev_id = db.Column(db.Integer, db.ForeignKey('item.id'))
-    prev = db.relationship('Item', foreign_keys=[prev_id], uselist=False)
-    ignore = db.relationship('Item', secondary=ignore_table)
+    categories = db.relationship('AnnotatorCategory', cascade="all,delete")
 
-    alpha = db.Column(db.Float)
-    beta = db.Column(db.Float)
-
-    def __init__(self, name, email, description):
+    def __init__(self, name, email, description, *categories):
         self.name = name
         self.email = email
         self.description = description
-        self.alpha = crowd_bt.ALPHA_PRIOR
-        self.beta = crowd_bt.BETA_PRIOR
         self.secret = utils.gen_secret(32)
+        self.categories = [
+            AnnotatorCategory(-1, Category.by_name_or_id(category).id)
+            for category in categories
+        ]
 
-    def update_next(self, new_next):
-        if new_next is not None:
-            new_next.prioritized = False # it's now assigned, so cancel the prioritization
-            # it could happen that the judge skips the project, but that
-            # doesn't re-prioritize the project
-            self.updated = datetime.utcnow()
-        self.next = new_next
+    def get_category(self, category_id):
+        for category in self.categories:
+            if category.category_id == int(category_id):
+                return category
 
     @classmethod
     def by_secret(cls, secret):

--- a/gavel/models/category.py
+++ b/gavel/models/category.py
@@ -1,0 +1,37 @@
+from gavel.models import db
+from datetime import datetime
+
+from sqlalchemy.orm.exc import NoResultFound
+
+class Category(db.Model):
+    id = db.Column(db.Integer, primary_key=True, nullable=False)
+    name = db.Column(db.Text, nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    annotators = db.relationship('AnnotatorCategory', cascade="all,delete")
+    items = db.relationship('ItemCategory', cascade="all,delete")
+
+    def __init__(self, name, description):
+        self.name = name
+        self.description = description
+
+    @classmethod
+    def by_id(cls, uid):
+        if uid is None:
+            return None
+        try:
+            item = cls.query.get(uid)
+        except NoResultFound:
+            item = None
+        return item
+
+    @classmethod
+    def by_name_or_id(cls, uid):
+        category = cls.by_id(uid)
+        if category:
+            return category
+
+        try:
+            return cls.query.filter(cls.name == uid).first()
+        except NoResultFound:
+            return None

--- a/gavel/models/decision.py
+++ b/gavel/models/decision.py
@@ -5,13 +5,16 @@ class Decision(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
     annotator_id = db.Column(db.Integer, db.ForeignKey('annotator.id'))
     annotator = db.relationship('Annotator', foreign_keys=[annotator_id], uselist=False)
+    category_id = db.Column(db.Integer, db.ForeignKey('category.id'))
+    category = db.relationship('Category', foreign_keys=[category_id], uselist=False)
     winner_id = db.Column(db.Integer, db.ForeignKey('item.id'))
     winner = db.relationship('Item', foreign_keys=[winner_id], uselist=False)
     loser_id = db.Column(db.Integer, db.ForeignKey('item.id'))
     loser = db.relationship('Item', foreign_keys=[loser_id], uselist=False)
     time = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
-    def __init__(self, annotator, winner, loser):
+    def __init__(self, annotator, winner, loser, category):
         self.annotator = annotator
         self.winner = winner
         self.loser = loser
+        self.category = category

--- a/gavel/models/item.py
+++ b/gavel/models/item.py
@@ -1,11 +1,43 @@
 from gavel.models import db
+from gavel.models.category import Category
 import gavel.crowd_bt as crowd_bt
 from sqlalchemy.orm.exc import NoResultFound
 
 view_table = db.Table('view',
-    db.Column('item_id', db.Integer, db.ForeignKey('item.id')),
+    db.Column('item_category_id', db.Integer, db.ForeignKey('item_category.id')),
     db.Column('annotator_id', db.Integer, db.ForeignKey('annotator.id'))
 )
+
+class ItemCategory(db.Model):
+    id = db.Column('id', db.Integer, primary_key=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'))
+    category_id = db.Column(db.Integer, db.ForeignKey('category.id'))
+    mu = db.Column(db.Float)
+    sigma_sq = db.Column(db.Float)
+    prioritized = db.Column(db.Boolean, default=False, nullable=False)
+
+    viewed = db.relationship('Annotator', secondary=view_table)
+    item = db.relationship('Item')
+    category = db.relationship('Category')
+
+
+    def __init__(self, item_id, category_id):
+        self.item_id = item_id
+        self.category_id = category_id
+        self.mu = crowd_bt.MU_PRIOR
+        self.sigma_sq = crowd_bt.SIGMA_SQ_PRIOR
+
+    @classmethod
+    def by_id(cls, uid):
+        if uid is None:
+            return None
+        try:
+            annotator = cls.query.with_for_update().get(uid)
+        except NoResultFound:
+            annotator = None
+        return annotator
+
+
 
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True, nullable=False)
@@ -13,18 +45,23 @@ class Item(db.Model):
     location = db.Column(db.Text, nullable=False)
     description = db.Column(db.Text, nullable=False)
     active = db.Column(db.Boolean, default=True, nullable=False)
-    viewed = db.relationship('Annotator', secondary=view_table)
-    prioritized = db.Column(db.Boolean, default=False, nullable=False)
+    categories = db.relationship('ItemCategory', cascade="all,delete")
 
-    mu = db.Column(db.Float)
-    sigma_sq = db.Column(db.Float)
-
-    def __init__(self, name, location, description):
+    def __init__(self, name, location, description, *categories):
         self.name = name
         self.location = location
         self.description = description
-        self.mu = crowd_bt.MU_PRIOR
-        self.sigma_sq = crowd_bt.SIGMA_SQ_PRIOR
+        self.categories = [
+            ItemCategory(-1, Category.by_name_or_id(category).id)
+            for category in categories
+        ]
+
+
+    def get_category(self, category_id):
+        for category in self.categories:
+            if category.category_id == int(category_id):
+                return category
+
 
     @classmethod
     def by_id(cls, uid):

--- a/gavel/static/css/style.scss
+++ b/gavel/static/css/style.scss
@@ -218,6 +218,19 @@ hr {
   background-color: $vote-color;
 }
 
+
+.card {
+  display: block;
+  cursor: pointer;
+  border: 1px solid $dark;
+  padding: 1rem;
+  margin: 1rem;
+}
+
+.card:hover {
+  text-decoration: none;
+}
+
 input[type=submit] {
   color: $light;
   background-color: $dark;
@@ -306,4 +319,9 @@ input[type=submit].neutral {
     font-size: 0.75rem;
     text-align: center;
   }
+}
+
+#subcategoryfooter {
+  padding: 1rem;
+  text-align: center;
 }

--- a/gavel/templates/_categories.html
+++ b/gavel/templates/_categories.html
@@ -1,0 +1,3 @@
+{% for category in categories %}
+  <a href="{{ url_for('category_detail', category_id=category.category.id) }}">{{ category.category.name | safe }}</a>{{ "," if not loop.last }}
+{% endfor %}

--- a/gavel/templates/_subcategoryfooter.html
+++ b/gavel/templates/_subcategoryfooter.html
@@ -1,0 +1,3 @@
+<div id="subcategoryfooter" class="info">
+  <a href="/">View All Categories</a>
+</div>

--- a/gavel/templates/admin.html
+++ b/gavel/templates/admin.html
@@ -18,6 +18,49 @@
 
 <div class="item">
   <div class="banner">
+    <h2>Categories</h2>
+  </div>
+  <div class="info">
+    <table id="categories">
+      <thead>
+        <tr>
+          <th data-sort-method="number">Id</th>
+          <th data-sort-method="caseInsensitiveSort">Name</th>
+          <th data-sort-method="caseInsensitiveSort">Description</th>
+          <th data-sort-method="caseInsensitiveSort">Active</th>
+          <th class="no-sort">Delete</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for category in categories %}
+        <tr class="{{ 'disabled' if not category.active else '' }}">
+          <td><a href="{{ url_for('category_detail', category_id=category.id) }}" class="colored">{{ category.id }}</a></td>
+          <td>{{ category.name | safe }}</td>
+          <td class="preserve-formatting">{{ category.description | safe }}</td>
+          <td class="compact" data-sort="{{ category.active }}">
+            <form action="/admin/category" method="post">
+              <input type="submit" name="action" value="{{ 'Disable' if category.active
+              else 'Enable' }}" class="{{ 'negative' if category.active else 'positive' }}">
+              <input type="hidden" name="category_id" value="{{ category.id }}">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+            </form>
+          </td>
+          <td class="compact">
+            <form action="/admin/category" method="post">
+              <input type="submit" name="action" value="Delete" class="negative">
+              <input type="hidden" name="category_id" value="{{ category.id }}">
+              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="item">
+  <div class="banner">
     <h2>Projects</h2>
   </div>
   <div class="info">
@@ -28,35 +71,30 @@
           <th data-sort-method="caseInsensitiveSort">Name</th>
           <th data-sort-method="caseInsensitiveSort">Location</th>
           <th data-sort-method="caseInsensitiveSort">Description</th>
-          <th class="sort-default" data-sort-method="number" data-sort-order="desc">Mu</th>
-          <th data-sort-method="number">Sigma Squared</th>
+          <th data-sort-method="caseInsensitiveSort">Categories</th>
           <th data-sort-method="number">Votes</th>
           <th data-sort-method="number">Seen</th>
           <th data-sort-method="number" data-sort-order="desc">Skipped</th>
-          <th data-sort-method="caseInsensitiveSort" data-sort-order="desc">Prioritize</th>
           <th data-sort-method="caseInsensitiveSort">Active</th>
           <th class="no-sort">Delete</th>
         </tr>
       </thead>
       <tbody>
         {% for item in items %}
-        <tr class="{{ 'disabled' if not item.active else 'prioritized' if item.prioritized else '' }}">
+        <tr class="{{ 'disabled' if not item.active else '' }}">
           <td><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.id }}</a></td>
           <td>{{ item.name | safe }}</td>
           <td>{{ item.location | safe }}</td>
           <td class="preserve-formatting">{{ item.description | safe }}</td>
-          <td>{{ item.mu | round(4) }}</td>
-          <td>{{ item.sigma_sq | round(4) }}</td>
-          <td>{{ item_counts.get(item.id, 0) }}</td>
-          <td>{{ item.viewed | length }}</td>
-          <td>{{ skipped.get(item.id, 0) }}</td>
-          <td class="compact" data-sort="{{ item.prioritized }}">
-            <form action="/admin/item" method="post">
-              <input type="submit" name="action" value="{{ 'Prioritize' if not item.prioritized else 'Cancel' }}" class="{{ 'positive' if not item.prioritized else 'negative' }}">
-              <input type="hidden" name="item_id" value="{{ item.id }}">
-              <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-            </form>
+          <td>
+            {% with categories=item.categories %}
+            {% include "_categories.html" %}
+            {% endwith %}
           </td>
+          <td>{{ item_counts.get(item.id, 0) }}</td>
+          <td>{{ viewed.get(item.id, {}) | length }}</td>
+          <td>{{ skipped.get(item.id, 0) }}</td>
+
           <td class="compact" data-sort="{{ item.active }}">
             <form action="/admin/item" method="post">
               <input type="submit" name="action" value="{{ 'Disable' if item.active else 'Enable' }}" class="{{ 'negative' if item.active else 'positive' }}">
@@ -91,9 +129,7 @@
           <th data-sort-method="caseInsensitiveSort">Email</th>
           <th data-sort-method="caseInsensitiveSort">Description</th>
           <th data-sort-method="number">Votes</th>
-          <th data-sort-method="number">Next (Id)</th>
-          <th data-sort-method="number">Previous (Id)</th>
-          <th data-sort-method="number" data-sort-order="desc">Updated</th>
+          <th data-sort-method="caseInsensitiveSort">Categories</th>
           <th class="no-sort">Email</th>
           <th data-sort-method="caseInsensitiveSort">Active</th>
           <th class="no-sort">Delete</th>
@@ -107,9 +143,12 @@
           <td>{{ annotator.email | safe }}</td>
           <td>{{ annotator.description | safe }}</td>
           <td>{{ counts.get(annotator.id, 0) }}</td>
-          <td data-sort="{{ annotator.next_id or -1 }}">{{ annotator.next_id }}</td>
-          <td data-sort="{{ annotator.prev_id or -1 }}">{{ annotator.prev_id }}</td>
-          <td data-sort="{{ annotator.updated | utcdatetime_epoch }}">{{ annotator.updated | utcdatetime_local }}</td>
+          <td>
+            {% with categories=annotator.categories %}
+            {% include "_categories.html" %}
+            {% endwith %}
+          </td>
+
           <td class="compact">
             <form action="/admin/annotator" method="post">
               <input type="submit" name="action" value="Email" class="neutral">
@@ -140,10 +179,28 @@
 
 <div class="item">
   <div class="banner">
+    <h2>Add Categories</h2>
+  </div>
+  <div class="info">
+    <p>Add name, description (CSV format)</p>
+    <textarea name="data" form="category_form"></textarea>
+    <form action="/admin/category" method="post" id="category_form" enctype="multipart/form-data">
+      <div class="upload-container">
+        <span class="field">Or upload a file here:</span>
+        <input type="file" name="file" accept=".csv,.xls,.xlsx">
+      </div>
+      <input type="submit" name="action" value="Submit" class="button-full positive">
+      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    </form>
+  </div>
+</div>
+
+<div class="item">
+  <div class="banner">
     <h2>Add Projects</h2>
   </div>
   <div class="info">
-    <p>Add name, location, description (CSV format)</p>
+    <p>Add name, location, description, [category 1, category 2, ...] (CSV format)</p>
     <textarea name="data" form="item_form"></textarea>
     <form action="/admin/item" method="post" id="item_form" enctype="multipart/form-data">
       <div class="upload-container">
@@ -155,12 +212,13 @@
     </form>
   </div>
 </div>
+
 <div class="item">
   <div class="banner">
     <h2>Add Judges</h2>
   </div>
   <div class="info">
-    <p>Add name, email, description (CSV format)</p>
+    <p>Add name, email, description, [category 1, category 2, ...] (CSV format)</p>
     <textarea name="data" form="annotator_form"></textarea>
     <form action="/admin/annotator" method="post" id="annotator_form" enctype="multipart/form-data">
       <div class="upload-container">
@@ -210,6 +268,7 @@
 var tables = [
   document.getElementById('items'),
   document.getElementById('annotators'),
+  document.getElementById('categories'),
 ];
 for (var i = 0; i < tables.length; i++) {
   new Tablesort(tables[i]);

--- a/gavel/templates/admin_annotator.html
+++ b/gavel/templates/admin_annotator.html
@@ -28,51 +28,51 @@
         <td><a href="{{ login_link }}">{{ login_link }}</a></td>
       </tr>
       <tr>
-        <th>Next</th>
-        {% if annotator.next %}
-        <td><a href="{{ url_for('item_detail', item_id=annotator.next.id) }}" class="colored">{{ annotator.next.name | safe }} [{{ annotator.next_id }}]</a></td>
-        {% else %}
-        <td>None</td>
-        {% endif %}
-      </tr>
-      <tr>
-        <th>Previous</th>
-        {% if annotator.prev %}
-        <td><a href="{{ url_for('item_detail', item_id=annotator.prev.id) }}" class="colored">{{ annotator.prev.name | safe }} [{{ annotator.prev_id }}]</a></td>
-        {% else %}
-        <td>None</td>
-        {% endif %}
-      </tr>
-      <tr>
-        <th>Updated</th>
-        <td>{{ annotator.updated | utcdatetime_local }}</td>
-      </tr>
-      <tr>
-        <th>Alpha</th>
-        <td>{{ annotator.alpha | round(4) }}</td>
-      </tr>
-      <tr>
-        <th>Beta</th>
-        <td>{{ annotator.beta | round(4) }}</td>
-      </tr>
-      <tr>
-        <th>Seen</th>
+        <th>Categories</th>
         <td>
-          <ul>
-            {% for item in seen %}
-            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name | safe }} [{{ item.id }}]</a></li>
-            {% endfor %}
-          </ul>
-        </td>
-      </tr>
-      <tr>
-        <th>Skipped</th>
-        <td>
-          <ul>
-            {% for item in skipped %}
-            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name | safe }} [{{ item.id }}]</a></li>
-            {% endfor %}
-          </ul>
+          <table>
+            <thead>
+              <tr>
+                <th data-sort-method="number">Id</th>
+                <th data-sort-method="caseInsensitiveSort">Name</th>
+                <th class="no-sort">Delete</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for category in annotator.categories %}
+                <tr>
+                  <td><a href="{{ url_for('category_detail', category_id=category.category_id) }}" class="colored">{{ category.category_id }}</a></td>
+                  <td>
+                    {{ category.category.name | safe }}
+                  </td>
+                  <td class="compact">
+                    <form action="/admin/annotator_patch" method="post">
+                      <input type="submit" name="action" value="Delete Category" class="neutral">
+                      <input type="hidden" name="annotator_id" value="{{ annotator.id }}">
+                      <input type="hidden" name="annotator_category_id" value="{{ category.id }}">
+                      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                    </form>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+
+
+          <form action="/admin/annotator_patch" method="post">
+            <select name="category_id">
+              {% for category in categories %}
+                <option value="{{ category.id }}">
+                  {{ category.id }}.
+                  {{ category.name }}
+                </option>
+              {% endfor %}
+            </select>
+
+            <input type="submit" name="action" value="Add Category" class="neutral">
+            <input type="hidden" name="annotator_id" value="{{ annotator.id }}">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          </form>
         </td>
       </tr>
     </table>

--- a/gavel/templates/admin_category.html
+++ b/gavel/templates/admin_category.html
@@ -1,0 +1,125 @@
+{% extends "layout.html" %}
+{% block title %}Category{% endblock %}
+{% block content %}
+<div class="item">
+  <div class="banner" id="admin-header">
+    <a href="{{ url_for('admin') }}"><h1>Category</h1></a>
+  </div>
+  <div class="info">
+    <table>
+      <tr>
+        <th>Id</th>
+        <td>{{ category.id }}</td>
+      </tr>
+      <tr>
+        <th>Name</th>
+        <td>
+          <form action="/admin/category_patch" method="post">
+            <input type="text" name="name" value="{{ category.name | safe }}">
+            <input type="submit" name="action" value="Update" class="neutral">
+            <input type="hidden" name="category_id" value="{{ category.id }}">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          </form>
+        </td>
+      </tr>
+      <tr>
+        <th>Description</th>
+        <td>
+          <textarea name="description" form="description_form">{{ category.description | safe }}</textarea>
+          <form action="/admin/category_patch" method="post" id="description_form">
+            <input type="submit" name="action" value="Update" class="neutral">
+            <input type="hidden" name="category_id" value="{{ category.id }}">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          </form>
+        </td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<div class="item">
+  <div class="banner">
+    <h2>Projects</h2>
+  </div>
+  <div class="info">
+    <table id="items">
+      <thead>
+        <tr>
+          <th data-sort-method="number">Id</th>
+          <th data-sort-method="caseInsensitiveSort">Name</th>
+          <th data-sort-method="caseInsensitiveSort">Location</th>
+          <th data-sort-method="caseInsensitiveSort">Description</th>
+          <th class="sort-default" data-sort-method="number" data-sort-order="desc">Mu</th>
+          <th data-sort-method="number">Sigma Squared</th>
+          <th data-sort-method="number">Votes</th>
+          <th data-sort-method="number">Seen</th>
+          <th data-sort-method="number" data-sort-order="desc">Skipped</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for item in items %}
+        <tr class="{{ 'disabled' if not item.item.active else '' }}">
+          <td><a href="{{ url_for('item_detail', item_id=item.item.id) }}" class="colored">{{ item.item.id }}</a></td>
+          <td>{{ item.item.name | safe }}</td>
+          <td>{{ item.item.location | safe }}</td>
+          <td class="preserve-formatting">{{ item.item.description | safe }}</td>
+          <td>{{ item.mu | round(4) }}</td>
+          <td>{{ item.sigma_sq | round(4) }}</td>
+          <td>{{ item_counts.get(item.item_id, 0) }}</td>
+          <td>{{ viewed.get(item.item_id, {}) | length }}</td>
+          <td>{{ skipped.get(item.item_id, 0) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="item">
+  <div class="banner">
+    <h2>Judges</h2>
+  </div>
+  <div class="info">
+    <table id="annotators">
+      <thead>
+        <tr>
+          <th class="sort-default" data-sort-method="number">Id</th>
+          <th data-sort-method="caseInsensitiveSort">Name</th>
+          <th data-sort-method="caseInsensitiveSort">Email</th>
+          <th data-sort-method="caseInsensitiveSort">Description</th>
+          <th data-sort-method="number">Votes</th>
+          <th data-sort-method="number">Next (Id)</th>
+          <th data-sort-method="number">Previous (Id)</th>
+          <th data-sort-method="number" data-sort-order="desc">Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for annotator in annotators %}
+        <tr class="{{ 'disabled' if not annotator.annotator.active else '' }}">
+          <td><a href="{{ url_for('annotator_detail', annotator_id=annotator.annotator_id) }}" class="colored">{{ annotator.annotator_id }}</a></td>
+          <td>{{ annotator.annotator.name | safe }}</td>
+          <td>{{ annotator.annotator.email | safe }}</td>
+          <td>{{ annotator.annotator.description | safe }}</td>
+          <td>{{ counts.get(annotator.annotator_id, 0) }}</td>
+          <td data-sort="{{ annotator.next_id or -1 }}">{{ annotator.next_id }}</td>
+          <td data-sort="{{ annotator.prev_id or -1 }}">{{ annotator.prev_id }}</td>
+          <td data-sort="{{ annotator.updated | utcdatetime_epoch }}">{{ annotator.updated | utcdatetime_local }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script src="{{ url_for('static', filename='js/vendor/tablesort.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/vendor/tablesort.number.js') }}"></script>
+<script>
+var tables = [
+  document.getElementById('items'),
+  document.getElementById('annotators'),
+];
+for (var i = 0; i < tables.length; i++) {
+  new Tablesort(tables[i]);
+}
+</script>
+{% endblock %}

--- a/gavel/templates/admin_item.html
+++ b/gavel/templates/admin_item.html
@@ -45,14 +45,6 @@
         </td>
       </tr>
       <tr>
-        <th>Mu</th>
-        <td>{{ item.mu }}</td>
-      </tr>
-      <tr>
-        <th>Sigma Squared</th>
-        <td>{{ item.sigma_sq }}</td>
-      </tr>
-      <tr>
         <th>Seen By</th>
         <td>
           <ul>
@@ -80,6 +72,54 @@
             <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name | safe }} [{{ annotator.id }}]</a></li>
             {% endfor %}
           </ul>
+        </td>
+      </tr>
+      <tr>
+        <th>Categories</th>
+        <td>
+          <table>
+            <thead>
+              <tr>
+                <th data-sort-method="number">Id</th>
+                <th data-sort-method="caseInsensitiveSort">Name</th>
+                <th class="no-sort">Delete</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for category in item.categories %}
+                <tr>
+                  <td><a href="{{ url_for('category_detail', category_id=category.category_id) }}" class="colored">{{ category.category_id }}</a></td>
+                  <td>
+                    {{ category.category.name | safe }}
+                  </td>
+                  <td class="compact">
+                    <form action="/admin/item_patch" method="post">
+                      <input type="submit" name="action" value="Delete Category" class="neutral">
+                      <input type="hidden" name="item_id" value="{{ item.id }}">
+                      <input type="hidden" name="item_category_id" value="{{ category.id }}">
+                      <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+                    </form>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+
+
+          <form action="/admin/item_patch" method="post">
+            <select name="category_id">
+              {% for category in categories %}
+                <option value="{{ category.id }}">
+                  {{ category.id }}.
+                  {{ category.name }}
+                </option>
+              {% endfor %}
+            </select>
+
+            <input type="submit" name="action" value="Add Category" class="neutral">
+            <input type="hidden" name="item_id" value="{{ item.id }}">
+            <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+          </form>
         </td>
       </tr>
     </table>

--- a/gavel/templates/begin.html
+++ b/gavel/templates/begin.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="item">
   <div class="banner-tight">
-    <h1>Start</h1>
+    <h1>{{ category.name }}: Start</h1>
   </div>
   {% with item=item %}
   {% include "_item.html" %}
@@ -15,9 +15,12 @@
     <form action="/begin" method="post">
       <input type="submit" name="action" value="Skip" id="vote-skip" class="button-full">
       <input type="submit" name="action" value="Done" id="vote-done" class="button-full button-gap">
+      <input type="hidden" name="category_id" value="{{ category.id }}">
       <input type="hidden" name="item_id" value="{{ item.id }}">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     </form>
   </div>
+
+  {% include "_subcategoryfooter.html" %}
 </div>
 {% endblock %}

--- a/gavel/templates/categories.html
+++ b/gavel/templates/categories.html
@@ -1,0 +1,22 @@
+{% extends "layout.html" %}
+{% block title %}Start{% endblock %}
+{% block content %}
+<div class="item">
+  <div class="banner-tight">
+    <h1>Categories</h1>
+  </div>
+</div>
+
+<div class="item">
+  <div class="info">
+    <p>Pick the category you want to judge for.</p>
+
+    {% for category in categories %}
+      <a href="{{ url_for('judge', category_id=category.id) }}" class="card">
+        <h2>{{ category.name | safe }}</h2>
+        <p>{{ category.description | safe }}</p>
+      </a>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/gavel/templates/closed.html
+++ b/gavel/templates/closed.html
@@ -8,5 +8,7 @@
   <div class="info">
     {{ content }}
   </div>
+
+  {% include "_subcategoryfooter.html" %}
 </div>
 {% endblock %}

--- a/gavel/templates/layout.html
+++ b/gavel/templates/layout.html
@@ -27,7 +27,9 @@
       {% block content %}
       {% endblock %}
     </div>
+
     <div id="footer">
+      <p>
       <!-- Please don't remove this -->
       <p>Powered by <a href="https://github.com/anishathalye/gavel" class="colored">Gavel</a></p>
     </div>

--- a/gavel/templates/vote.html
+++ b/gavel/templates/vote.html
@@ -25,7 +25,7 @@
 
 <div class="item">
   <div class="banner" id="vote-header">
-    <h1>Vote</h1>
+    <h1>{{ category.name }}: Vote</h1>
   </div>
   <div class="info">
     <form action="/vote" method="post">
@@ -33,10 +33,13 @@
       <input type="submit" name="action" value="Previous" id="vote-previous" class="button-left">
       <input type="submit" name="action" value="Current" id="vote-current" class="button-right">
       <input type="submit" name="action" value="Skip" id="vote-skip" class="button-full button-gap">
+      <input type="hidden" name="category_id" value="{{ category.id }}">
       <input type="hidden" name="prev_id" value="{{ prev.id }}">
       <input type="hidden" name="next_id" value="{{ next.id }}">
       <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
     </form>
   </div>
+
+  {% include "_subcategoryfooter.html" %}
 </div>
 {% endblock %}

--- a/gavel/templates/wait.html
+++ b/gavel/templates/wait.html
@@ -8,5 +8,7 @@
   <div class="info">
     {{ content }}
   </div>
+
+  {% include "_subcategoryfooter.html" %}
 </div>
 {% endblock %}


### PR DESCRIPTION
This adds multiple categories. These are designed so there can be more
than one judging session/category going on at the same time.  nwHacks is
planning on creating an overall category, a popular vote category and a
category for each sponsor prize.

This is implemented by adding new models: Category, ItemCategory and
AnnotatorCategory. mu, sigma_sq, prioritized, viewed and ignore have
been moved into the per category models.

When a user encounters the judging interface they are asked to specify
which category they want to judge for. If they only have one category
available (/active) they are automatically redirected to that category.

You can also optionally set categories while importing via CSV.

The updated admin interface is a little bit rough, but workable. I think I stamped out most of the bugs I introduced, but I'd appreciate someone looking over it.

## user interface

![localhost_5000_category_1_ nexus 6p](https://user-images.githubusercontent.com/909104/34592205-48bb27aa-f177-11e7-855e-ee5e5ba08390.png)
![localhost_5000_ nexus 6p](https://user-images.githubusercontent.com/909104/34592206-48d621c2-f177-11e7-8e4c-64d2b2d9f326.png)

## admin interface

![localhost_5000_admin_item_1_](https://user-images.githubusercontent.com/909104/34592211-4e872170-f177-11e7-99a4-517a9c84f057.png)
![localhost_5000_admin_annotator_1_](https://user-images.githubusercontent.com/909104/34592212-4e9b6f40-f177-11e7-9253-407b7a5bb8d1.png)
![localhost_5000_admin_](https://user-images.githubusercontent.com/909104/34592214-4eca42ac-f177-11e7-8fe7-5fc8c33a9673.png)
![localhost_5000_admin_category_2_ 1](https://user-images.githubusercontent.com/909104/34592249-82900720-f177-11e7-9f52-0fcf21932953.png)

