### PR TITLE
Added Sendgrid features

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -42,6 +42,12 @@ secret_key: null
 # Optional Settings #
 #####################
 
+# can also configure Gavel to use SendGrid to send emails
+# Set use_sendgrid to be true. Default value is false
+# also, add in your API key. Default value for that is None.
+use_sendgrid: null
+sendgrid_api_key: null
+
 # can also be specified as the 'DATABASE_URL' or 'DB_URI' environment variable
 # defaults to 'postgresql://localhost/gavel'
 db_uri: null

--- a/gavel/controllers/admin.py
+++ b/gavel/controllers/admin.py
@@ -235,4 +235,7 @@ def email_invite_links(annotators):
         body = '\n\n'.join(utils.get_paragraphs(raw_body))
         emails.append((annotator.email, settings.EMAIL_SUBJECT, body))
 
-    utils.send_emails.delay(emails)
+    if settings.USE_SENDGRID and settings.SENDGRID_API_KEY != None:
+        utils.send_sendgrid_emails(emails)
+    else:
+        utils.send_emails.delay(emails)

--- a/gavel/settings.py
+++ b/gavel/settings.py
@@ -79,3 +79,5 @@ EMAIL_CC =      _list(c.get('email_cc',        'EMAIL_CC',                 defau
 EMAIL_SUBJECT =       c.get('email_subject',                               default=constants.DEFAULT_EMAIL_SUBJECT)
 EMAIL_BODY =          c.get('email_body',                                  default=constants.DEFAULT_EMAIL_BODY)
 SEND_STATS =    _bool(c.get('send_stats',      'SEND_STATS',               default=True))
+USE_SENDGRID =   bool(c.get('use_sendgrid',    'USE_SENDGRID',             default=False))
+SENDGRID_API_KEY =   (c.get('sendgrid_api_key','SENDGRID_API_KEY',         default=None))


### PR DESCRIPTION
We talked about adding SendGrid to Gavel in #68. This PR directly addresses that.
1. I added some settings in `config.yaml` that users can edit to be able to use SendGrid. They can put in their API keys and enable sendgrid.
2. I edited `admin.py` to send emails via sendgrid. `admin.py` calls `send_sendgrid_emails`, which is located in `utils.py`. I added this method and another method `send_sendgrid_emails` which actually creates the JSON schema and sends the requests.