### PR TITLE
Allow unencrypted smtp

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -114,7 +114,7 @@ disable_email: null
 # can also be specified as the 'EMAIl_AUTH_MODE' environment variable
 # defaults to 'tls'
 #
-# can either be 'tls' or 'ssl'. if you are setting DISABLE_EMAIL, you can set
+# can either be 'tls', 'ssl' or 'none'. if you are setting DISABLE_EMAIL, you can set
 # this setting to '_unused_' (or anything else).
 email_auth_mode: null
 

--- a/gavel/utils.py
+++ b/gavel/utils.py
@@ -66,6 +66,9 @@ def send_emails(emails):
         server.ehlo()
     elif settings.EMAIL_AUTH_MODE == 'ssl':
         server = smtplib.SMTP_SSL(settings.EMAIL_HOST, settings.EMAIL_PORT)
+    elif settings.EMAIL_AUTH_MODE == 'none':
+        server = smtplib.SMTP(settings.EMAIL_HOST, settings.EMAIL_PORT)
+        server.ehlo()
     else:
         raise ValueError('unsupported auth mode: %s' % settings.EMAIL_AUTH_MODE)
 


### PR DESCRIPTION
This allows one to use a local postfix agent or a sinkhole Docker container to handle mails from gavel.