### PR TITLE
Bump pyScss version to fix local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/anishathalye/gavel/docs/banner.png" width="450" height="150" alt="Gavel banner">
+<img src="https://raw.githubusercontent.com/anishathalye/gavel/docs/banner.png" width="450" alt="Gavel banner">
 
 **Gavel** is a project expo judging system.
 
@@ -15,7 +15,7 @@ keep us going <3**
 
 <p align="center">
     <a href="http://www.anishathalye.com/2016/09/19/gavel-an-expo-judging-system/">
-        <img src="https://raw.githubusercontent.com/anishathalye/gavel/docs/screenshot.png" width="320" height="568" alt="Gavel screenshot">
+        <img src="https://raw.githubusercontent.com/anishathalye/gavel/docs/screenshot.png" width="320" alt="Gavel screenshot">
     </a>
 </p>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ MarkupSafe==1.1.1
 more-itertools==8.0.2
 numpy==1.18.0
 psycopg2==2.8.4
-pyScss==1.3.5
+pyScss==1.3.7
 pytz==2019.3
 PyYAML==5.2
 redis==3.3.11


### PR DESCRIPTION
I was following DEVELOPMENT.md and using the Vagrant route but ran into a `pip install` error:

```
Collecting psycopg2==2.8.4
  Using cached psycopg2-2.8.4.tar.gz (377 kB)
Collecting pyScss==1.3.5
  Using cached pyScss-1.3.5.tar.gz (123 kB)
    ERROR: Command errored out with exit status 1:
     command: /gavel/env/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-d3yyy60h/pyScss/setup.py'"'"'; __file__='"'"'/tmp/pip-install-d3yyy60h/pyScss/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-d3yyy60h/pyScss/pip-egg-info
         cwd: /tmp/pip-install-d3yyy60h/pyScss/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-d3yyy60h/pyScss/setup.py", line 9, in <module>
        from setuptools import setup, Extension, Feature
    ImportError: cannot import name 'Feature' from 'setuptools' (/gavel/env/lib/python3.7/site-packages/setuptools/__init__.py)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

Apparently this was an [intended change](https://github.com/pypa/setuptools/issues/2017) by PyPA, but I don't understand why they did not [clean up](https://github.com/pypa/setuptools/issues/2017#issuecomment-610860563) their `__init__.py`.

Because downgrading the `setuptools` given to me by `virtualenv` felt wrong, I opted to instead bump `pyScss` up two minor versions from `1.3.5` to `1.3.7`.

I think this is including a commit you made in `master` that doesn't exist in `develop`.  Let me know if I'm PRing into the right branch.  Thank you!