### PR TITLE
Resolve XSS vulnerability: do not mark unsafe inputs as 'safe'

### DIFF
--- a/gavel/templates/_item.html
+++ b/gavel/templates/_item.html
@@ -1,5 +1,5 @@
 <div class="info">
-  <h2>{{ item.name | safe }}</h2>
-  <p class="preserve-formatting">{{ item.description | safe }}</p>
-  <p><strong>Location: </strong>{{ item.location | safe }}</p>
+  <h2>{{ item.name }}</h2>
+  <p class="preserve-formatting">{{ item.description }}</p>
+  <p><strong>Location: </strong>{{ item.location }}</p>
 </div>

--- a/gavel/templates/admin.html
+++ b/gavel/templates/admin.html
@@ -42,9 +42,9 @@
         {% for item in items %}
         <tr class="{{ 'disabled' if not item.active else 'prioritized' if item.prioritized else '' }}">
           <td><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.id }}</a></td>
-          <td>{{ item.name | safe }}</td>
-          <td>{{ item.location | safe }}</td>
-          <td class="preserve-formatting">{{ item.description | safe }}</td>
+          <td>{{ item.name }}</td>
+          <td>{{ item.location }}</td>
+          <td class="preserve-formatting">{{ item.description }}</td>
           <td>{{ item.mu | round(4) }}</td>
           <td>{{ item.sigma_sq | round(4) }}</td>
           <td>{{ item_counts.get(item.id, 0) }}</td>
@@ -106,9 +106,9 @@
         {% for annotator in annotators %}
         <tr class="{{ 'disabled' if not annotator.active else '' }}">
           <td><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.id }}</a></td>
-          <td>{{ annotator.name | safe }}</td>
-          <td>{{ annotator.email | safe }}</td>
-          <td>{{ annotator.description | safe }}</td>
+          <td>{{ annotator.name }}</td>
+          <td>{{ annotator.email }}</td>
+          <td>{{ annotator.description }}</td>
           <td>{{ counts.get(annotator.id, 0) }}</td>
           <td data-sort="{{ annotator.next_id or -1 }}">{{ annotator.next_id }}</td>
           <td data-sort="{{ annotator.prev_id or -1 }}">{{ annotator.prev_id }}</td>

--- a/gavel/templates/admin_annotator.html
+++ b/gavel/templates/admin_annotator.html
@@ -13,15 +13,15 @@
       </tr>
       <tr>
         <th>Name</th>
-        <td>{{ annotator.name | safe }}</td>
+        <td>{{ annotator.name }}</td>
       </tr>
       <tr>
         <th>Email</th>
-        <td>{{ annotator.email | safe }}</td>
+        <td>{{ annotator.email }}</td>
       </tr>
       <tr>
         <th>Description</th>
-        <td>{{ annotator.description | safe }}</td>
+        <td>{{ annotator.description }}</td>
       </tr>
       <tr>
         <th>Login URL</th>
@@ -30,7 +30,7 @@
       <tr>
         <th>Next</th>
         {% if annotator.next %}
-        <td><a href="{{ url_for('item_detail', item_id=annotator.next.id) }}" class="colored">{{ annotator.next.name | safe }} [{{ annotator.next_id }}]</a></td>
+        <td><a href="{{ url_for('item_detail', item_id=annotator.next.id) }}" class="colored">{{ annotator.next.name }} [{{ annotator.next_id }}]</a></td>
         {% else %}
         <td>None</td>
         {% endif %}
@@ -38,7 +38,7 @@
       <tr>
         <th>Previous</th>
         {% if annotator.prev %}
-        <td><a href="{{ url_for('item_detail', item_id=annotator.prev.id) }}" class="colored">{{ annotator.prev.name | safe }} [{{ annotator.prev_id }}]</a></td>
+        <td><a href="{{ url_for('item_detail', item_id=annotator.prev.id) }}" class="colored">{{ annotator.prev.name }} [{{ annotator.prev_id }}]</a></td>
         {% else %}
         <td>None</td>
         {% endif %}
@@ -60,7 +60,7 @@
         <td>
           <ul>
             {% for item in seen %}
-            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name | safe }} [{{ item.id }}]</a></li>
+            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name }} [{{ item.id }}]</a></li>
             {% endfor %}
           </ul>
         </td>
@@ -70,7 +70,7 @@
         <td>
           <ul>
             {% for item in skipped %}
-            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name | safe }} [{{ item.id }}]</a></li>
+            <li><a href="{{ url_for('item_detail', item_id=item.id) }}" class="colored">{{ item.name }} [{{ item.id }}]</a></li>
             {% endfor %}
           </ul>
         </td>

--- a/gavel/templates/admin_item.html
+++ b/gavel/templates/admin_item.html
@@ -15,7 +15,7 @@
         <th>Name</th>
         <td>
           <form action="{{ url_for('item_patch') }}" method="post">
-            <input type="text" name="name" value="{{ item.name | safe }}">
+            <input type="text" name="name" value="{{ item.name }}">
             <input type="submit" name="action" value="Update" class="neutral">
             <input type="hidden" name="item_id" value="{{ item.id }}">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
@@ -26,7 +26,7 @@
         <th>Location</th>
         <td>
           <form action="{{ url_for('item_patch') }}" method="post">
-            <input type="text" name="location" value="{{ item.location | safe }}">
+            <input type="text" name="location" value="{{ item.location }}">
             <input type="submit" name="action" value="Update" class="neutral">
             <input type="hidden" name="item_id" value="{{ item.id }}">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
@@ -36,7 +36,7 @@
       <tr>
         <th>Description</th>
         <td>
-          <textarea name="description" form="description_form">{{ item.description | safe }}</textarea>
+          <textarea name="description" form="description_form">{{ item.description }}</textarea>
           <form action="{{ url_for('item_patch') }}" method="post" id="description_form">
             <input type="submit" name="action" value="Update" class="neutral">
             <input type="hidden" name="item_id" value="{{ item.id }}">
@@ -57,7 +57,7 @@
         <td>
           <ul>
             {% for annotator in item.viewed %}
-            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name | safe }} [{{ annotator.id }}]</a></li>
+            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name }} [{{ annotator.id }}]</a></li>
             {% endfor %}
           </ul>
         </td>
@@ -67,7 +67,7 @@
         <td>
           <ul>
             {% for annotator in assigned %}
-            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name | safe }} [{{ annotator.id }}]</a></li>
+            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name }} [{{ annotator.id }}]</a></li>
             {% endfor %}
           </ul>
         </td>
@@ -77,7 +77,7 @@
         <td>
           <ul>
             {% for annotator in skipped %}
-            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name | safe }} [{{ annotator.id }}]</a></li>
+            <li><a href="{{ url_for('annotator_detail', annotator_id=annotator.id) }}" class="colored">{{ annotator.name }} [{{ annotator.id }}]</a></li>
             {% endfor %}
           </ul>
         </td>


### PR DESCRIPTION
Resolves an XSS vulnerability in Gavel. It is Jinja's default behaviour to escape any unsafe inputs so that they can be inserted into HTML content without leading to a security vulnerability. However, previous versions of Gavel used the "safe" filter to override this. As a result, if a malicious participant entered a description, email, etc. which contained HTML code, anybody who viewed the payload could have their session with Gavel hijacked if the HTML contained malicious JavaScript code. This class of vulnerability is known as 'cross-site scripting'.

To resolve the vulnerability, all instances of the "safe" filter are removed.

Hackathon organisers on older versions should sanitise participant data before importing them into Gavel.

**Although I'm currently trying to set up a local instance of Gavel (so these changes are untested), similar changes were made to a downstream fork with no issue (https://github.com/leios/gavel/commit/a5c9c8db097d068c1bcbf7418e5b2439a852992e)**