### PR TITLE
Fix database connection pool exhaustion from pessimistic locking

### DIFF
--- a/gavel/models/annotator.py
+++ b/gavel/models/annotator.py
@@ -56,7 +56,7 @@ class Annotator(db.Model):
         if uid is None:
             return None
         try:
-            annotator = cls.query.with_for_update().get(uid)
+            annotator = cls.query.get(uid)
         except NoResultFound:
             annotator = None
         return annotator


### PR DESCRIPTION
Remove `with_for_update()` from `Annotator.by_id()` to prevent deadlocks and connection pool saturation.

**Problem:**
- `with_for_update()` acquires a SELECT FOR UPDATE lock on annotator rows
- This lock is held during expensive queries (fetching all items/annotators)
- Concurrent requests for the same judge block waiting for the lock
- Each blocked request holds a database connection
- Connection pool becomes exhausted, causing application hangs

**Why the lock was unnecessary:**
- Database already uses SERIALIZABLE isolation level
- `with_retries()` wrapper handles serialization conflicts
- Optimistic concurrency control via SERIALIZABLE is sufficient
- Pessimistic locks are only needed for specific update patterns

**Impact:**
- Eliminates connection pool exhaustion under concurrent load
- Reduces transaction hold times
- Improves application responsiveness